### PR TITLE
Make the root `MatcherTransformer` lazy

### DIFF
--- a/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/ATypeMatcherTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/ATypeMatcherTransformer.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2javaext.scalatest.transformers.assertions.matchers
 
 import io.github.effiban.scala2javaext.scalatest.classifiers.ScalatestMatcherWordClassifier
-import io.github.effiban.scala2javaext.scalatest.common.HamcrestMatcherTerms.{IsA, SameInstance}
+import io.github.effiban.scala2javaext.scalatest.common.HamcrestMatcherTerms.IsA
 
 import scala.meta.Term
 import scala.meta.quasiquotes.XtensionQuasiquoteTerm

--- a/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/CompositeMatcherTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/CompositeMatcherTransformer.scala
@@ -2,7 +2,7 @@ package io.github.effiban.scala2javaext.scalatest.transformers.assertions.matche
 
 import scala.meta.Term
 
-private[transformers] class CompositeMatcherTransformer(matcherTransformers: List[MatcherTransformer]) extends MatcherTransformer {
+private[transformers] class CompositeMatcherTransformer(matcherTransformers: Seq[MatcherTransformer]) extends MatcherTransformer {
 
   override def transform(matcher: Term): Option[Term] = {
     matcherTransformers.foldLeft[Option[Term]](None)(

--- a/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/MatcherAssertionTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/MatcherAssertionTransformer.scala
@@ -3,6 +3,7 @@ package io.github.effiban.scala2javaext.scalatest.transformers.assertions.matche
 import io.github.effiban.scala2javaext.scalatest.classifiers.ScalatestAssertionWordClassifier
 import io.github.effiban.scala2javaext.scalatest.common.HamcrestMatcherTerms.AssertThat
 import io.github.effiban.scala2javaext.scalatest.common.ScalatestConstants.{Be, Equal}
+import io.github.effiban.scala2javaext.scalatest.transformers.assertions.matchers.MatcherTransformers.rootMatcherTransformer
 
 import scala.meta.Term
 
@@ -12,7 +13,7 @@ trait MatcherAssertionTransformer {
 }
 
 private[transformers] class MatcherAssertionTransformerImpl(assertionWordClassifier: ScalatestAssertionWordClassifier,
-                                                            matcherTransformer: MatcherTransformer)
+                                                            matcherTransformer: => MatcherTransformer)
   extends MatcherAssertionTransformer {
 
   override def transform(actual: Term, assertionWord: Term.Name, matcher: Term): Option[Term.Apply] = {
@@ -33,16 +34,4 @@ private[transformers] class MatcherAssertionTransformerImpl(assertionWordClassif
   }
 }
 
-object MatcherAssertionTransformer extends MatcherAssertionTransformerImpl(
-  ScalatestAssertionWordClassifier,
-  new CompositeMatcherTransformer(
-    List(
-      EqualMatcherTransformer,
-      BeMatcherTransformer,
-      HaveMatcherTransformer,
-      StringMatcherTransformer,
-      RegexMatcherTransformer,
-      ContainMatcherTransformer
-    )
-  )
-)
+object MatcherAssertionTransformer extends MatcherAssertionTransformerImpl(ScalatestAssertionWordClassifier, rootMatcherTransformer)

--- a/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/MatcherTransformers.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/MatcherTransformers.scala
@@ -1,0 +1,15 @@
+package io.github.effiban.scala2javaext.scalatest.transformers.assertions.matchers
+
+object MatcherTransformers {
+
+  private[matchers] lazy val rootMatcherTransformer = new CompositeMatcherTransformer(
+    LazyList(
+      BeMatcherTransformer,
+      ContainMatcherTransformer,
+      EqualMatcherTransformer,
+      HaveMatcherTransformer,
+      RegexMatcherTransformer,
+      StringMatcherTransformer
+    )
+  )
+}


### PR DESCRIPTION
This is a preparation for transforming the logical matchers, which can call each other recursively