### PR TITLE
Enhance `ContainMatcherTransformer`

### DIFF
--- a/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/ContainMatcherTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/ContainMatcherTransformer.scala
@@ -9,7 +9,7 @@ private[transformers] class ContainMatcherTransformer(nestedTransformer: Matcher
 
   override def transform(matcher: Term): Option[Term] = {
     matcher match {
-      case Term.Apply(q"contain", List(item: Term)) => Some(Term.Apply(HasItem, List(item)))
+      case Term.Apply(q"contain", List(term: Term)) => Some(transformNested(term).getOrElse(Term.Apply(HasItem, List(term))))
       case Term.ApplyInfix(q"contain", nestedMatcherWord: Term.Name, _, values) => transformNested(Term.Apply(nestedMatcherWord, values))
       case _ => None
     }

--- a/src/test/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/ContainMatcherTransformerTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/ContainMatcherTransformerTest.scala
@@ -11,9 +11,22 @@ class ContainMatcherTransformerTest extends UnitTestSuite {
 
   private val containMatcherTransformer = new ContainMatcherTransformer(nestedTransformer)
 
-  test("transform() a Term.Apply when fun is 'contain' with one arg, should return Hamcrest 'hasItem'") {
+  test("transform() a Term.Apply when fun is 'contain' with one arg, and nested transformer returns a result - should return it") {
+    val matcher = q"contain(allOf(3, 4))"
+    val nestedMatcher = q"allOf(3, 4)"
+    val expectedHamcrestMatcher = q"hasItems(3, 4)"
+
+    when(nestedTransformer.transform(eqTree(nestedMatcher))).thenReturn(Some(expectedHamcrestMatcher))
+
+    containMatcherTransformer.transform(matcher).value.structure shouldBe expectedHamcrestMatcher.structure
+  }
+
+  test("transform() a Term.Apply when fun is 'contain' with one arg, and nested transformer does not return a result - should return Hamcrest 'hasItem'") {
     val matcher = q"contain(3)"
+    val value = q"3"
     val expectedHamcrestMatcher = q"hasItem(3)"
+
+    when(nestedTransformer.transform(eqTree(value))).thenReturn(None)
 
     containMatcherTransformer.transform(matcher).value.structure shouldBe expectedHamcrestMatcher.structure
   }


### PR DESCRIPTION
Enhancing to make it work when the nested matcher is a `Term.Apply` as well (e.g. `contains(allOf(3, 4))`)

This is needed to support scenarios where the whole thing is nested in another matcher , e.g. `not contains allOf(3, 4)` - because to keep things simple the code will convert the nested matchers to `Term.Apply`-s, even if they are not permitted by the original  Scalatest syntax