### PR TITLE
Properly support transformation of nested infix matchers

### DIFF
--- a/src/main/scala/io/github/effiban/scala2javaext/scalatest/manipulators/TermApplyInfixManipulator.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/scalatest/manipulators/TermApplyInfixManipulator.scala
@@ -1,0 +1,22 @@
+package io.github.effiban.scala2javaext.scalatest.manipulators
+
+import scala.meta.Term
+
+trait TermApplyInfixManipulator {
+  def rightShiftInnerIfPossible(infix: Term.ApplyInfix): Option[Term.ApplyInfix]
+}
+
+object TermApplyInfixManipulator extends TermApplyInfixManipulator {
+
+  /** This method handles the case where a word is nested inside an inner infix and therefore would not be identified by a pattern.
+   * For example, given the matcher assertion '''x should have size 2''' - then '''x should have''' will be parsed as the LHS,
+   * so that '''size''' instead of '''should''' will be identified as the assertion word, and the corresponding transformer would fail.<br>
+   * To resolve this - a "right-shift" of the word 'have' produces: '''x should (have size 2)''' -
+   * and now '''should''' is recognized as the assertion word, as expected.
+   */
+  def rightShiftInnerIfPossible(infix: Term.ApplyInfix): Option[Term.ApplyInfix] = infix match {
+    case outer@Term.ApplyInfix(inner@Term.ApplyInfix(_, _, _, List(innerArg)), _, _, _) =>
+      Some(inner.copy(args = List(outer.copy(lhs = innerArg))))
+    case _ => None
+  }
+}

--- a/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/ScalatestTermApplyInfixToTermApplyTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/ScalatestTermApplyInfixToTermApplyTransformer.scala
@@ -2,36 +2,29 @@ package io.github.effiban.scala2javaext.scalatest.transformers
 
 import io.github.effiban.scala2java.spi.transformers.TermApplyInfixToTermApplyTransformer
 import io.github.effiban.scala2javaext.scalatest.classifiers.ScalatestAssertionWordClassifier
+import io.github.effiban.scala2javaext.scalatest.manipulators.TermApplyInfixManipulator
 import io.github.effiban.scala2javaext.scalatest.transformers.assertions.matchers.MatcherAssertionTransformer
 
 import scala.meta.Term
 
 private[transformers] class ScalatestTermApplyInfixToTermApplyTransformerImpl(matcherAssertionTransformer: MatcherAssertionTransformer,
-                                                                              assertionWordClassifier: ScalatestAssertionWordClassifier)
+                                                                              assertionWordClassifier: ScalatestAssertionWordClassifier,
+                                                                              termApplyInfixManipulator: TermApplyInfixManipulator)
   extends TermApplyInfixToTermApplyTransformer {
 
   override def transform(termApplyInfix: Term.ApplyInfix): Option[Term.Apply] = {
     import assertionWordClassifier._
+    import termApplyInfixManipulator._
+
     termApplyInfix match {
       case Term.ApplyInfix(actual, word, _, List(matcher)) if isAssertionWord(word) => matcherAssertionTransformer.transform(actual, word, matcher)
-      case outerInfix@Term.ApplyInfix(innerInfix@Term.ApplyInfix(_, _, _, List(innerArg)), _, _, _) =>
-        transform(rightShiftInfix(innerInfix, innerArg, outerInfix))
-      case _ => None
+      case infix => rightShiftInnerIfPossible(infix).flatMap(transform)
     }
-  }
-
-  /** This method handles the case where the assertion word is nested inside an inner infix and would not be identified by the basic pattern.
-   * For example, if the code is '''x should have size 2''' - then '''x should have''' will be parsed as the LHS, so that '''size''' instead of
-   * '''should''' will be matched by the basic pattern.<br>
-   * To resolve this - doing a "right-shift" of the word 'have' to obtain the following: '''x should (have size 2)''' -
-   * after which, a recursive call to transform() will be able to recognize it with the basic pattern.
-   */
-  private def rightShiftInfix(inner: Term.ApplyInfix, innerArg: Term, outer: Term.ApplyInfix) = {
-    inner.copy(args = List(outer.copy(lhs = innerArg)))
   }
 }
 
 object ScalatestTermApplyInfixToTermApplyTransformer extends ScalatestTermApplyInfixToTermApplyTransformerImpl(
   MatcherAssertionTransformer,
-  ScalatestAssertionWordClassifier
+  ScalatestAssertionWordClassifier,
+  TermApplyInfixManipulator
 )

--- a/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/MatcherTransformers.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/MatcherTransformers.scala
@@ -1,18 +1,23 @@
 package io.github.effiban.scala2javaext.scalatest.transformers.assertions.matchers
 
+import io.github.effiban.scala2javaext.scalatest.manipulators.TermApplyInfixManipulator
+
 object MatcherTransformers {
 
   private[matchers] lazy val logicalMatcherTransformer: MatcherTransformer = new LogicalMatcherTransformer(rootMatcherTransformer)
 
-  private[matchers] lazy val rootMatcherTransformer: MatcherTransformer = new CompositeMatcherTransformer(
-    LazyList(
-      BeMatcherTransformer,
-      ContainMatcherTransformer,
-      EqualMatcherTransformer,
-      HaveMatcherTransformer,
-      logicalMatcherTransformer,
-      RegexMatcherTransformer,
-      StringMatcherTransformer
-    )
+  private[matchers] lazy val rootMatcherTransformer: MatcherTransformer = new NestedInfixCapableMatcherTransformer(
+    new CompositeMatcherTransformer(
+      LazyList(
+        BeMatcherTransformer,
+        ContainMatcherTransformer,
+        EqualMatcherTransformer,
+        HaveMatcherTransformer,
+        logicalMatcherTransformer,
+        RegexMatcherTransformer,
+        StringMatcherTransformer
+      )
+    ),
+    TermApplyInfixManipulator
   )
 }

--- a/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/NestedInfixCapableMatcherTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/NestedInfixCapableMatcherTransformer.scala
@@ -1,0 +1,19 @@
+package io.github.effiban.scala2javaext.scalatest.transformers.assertions.matchers
+import io.github.effiban.scala2javaext.scalatest.manipulators.TermApplyInfixManipulator
+
+import scala.meta.Term
+
+class NestedInfixCapableMatcherTransformer(innerTransformer: => MatcherTransformer,
+                                           termApplyInfixManipulator: TermApplyInfixManipulator) extends MatcherTransformer {
+
+  override def transform(matcher: Term): Option[Term] = {
+    import termApplyInfixManipulator._
+
+    innerTransformer.transform(matcher).orElse {
+      matcher match {
+        case infix: Term.ApplyInfix => rightShiftInnerIfPossible(infix).flatMap(transform)
+        case _ => None
+      }
+    }
+  }
+}

--- a/src/test/scala/io/github/effiban/scala2javaext/scalatest/manipulators/TermApplyInfixManipulatorTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/scalatest/manipulators/TermApplyInfixManipulatorTest.scala
@@ -1,0 +1,21 @@
+package io.github.effiban.scala2javaext.scalatest.manipulators
+
+import io.github.effiban.scala2javaext.scalatest.manipulators.TermApplyInfixManipulator.rightShiftInnerIfPossible
+import io.github.effiban.scala2javaext.scalatest.testsuites.UnitTestSuite
+
+import scala.meta.XtensionQuasiquoteTerm
+
+class TermApplyInfixManipulatorTest extends UnitTestSuite {
+
+  test("rightShiftInnerIfPossible() when LHS is a Term.Name - should return None") {
+    rightShiftInnerIfPossible(q"a + b") shouldBe None
+  }
+
+  test("rightShiftInnerIfPossible() when LHS is an infix with one arg - should return the shifted infix") {
+    rightShiftInnerIfPossible(q"(a + b) + c").value.structure shouldBe q"a + (b + c)".structure
+  }
+
+  test("rightShiftInnerIfPossible() when LHS is an infix with two args - should return None") {
+    rightShiftInnerIfPossible(q"a + (b, c)") shouldBe None
+  }
+}

--- a/src/test/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/NestedInfixCapableMatcherTransformerTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/scalatest/transformers/assertions/matchers/NestedInfixCapableMatcherTransformerTest.scala
@@ -1,0 +1,75 @@
+package io.github.effiban.scala2javaext.scalatest.transformers.assertions.matchers
+
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+import io.github.effiban.scala2javaext.scalatest.manipulators.TermApplyInfixManipulator
+import io.github.effiban.scala2javaext.scalatest.testsuites.UnitTestSuite
+import org.mockito.ArgumentMatchersSugar.any
+
+import scala.meta.{Term, XtensionQuasiquoteTerm}
+
+class NestedInfixCapableMatcherTransformerTest extends UnitTestSuite {
+
+  private val innerTransformer = mock[MatcherTransformer]
+  private val termApplyInfixManipulator = mock[TermApplyInfixManipulator]
+
+  private val outerTransformer = new NestedInfixCapableMatcherTransformer(
+    innerTransformer,
+    termApplyInfixManipulator
+  )
+
+  test("transform() a Term.ApplyInfix, when inner transformer returns a result - should return it") {
+    val matcher = q"have size(3)"
+    val expectedHamcrestMatcher = q"hasSize(3)"
+
+    when(innerTransformer.transform(eqTree(matcher))).thenReturn(Some(expectedHamcrestMatcher))
+
+    outerTransformer.transform(matcher).value.structure shouldBe expectedHamcrestMatcher.structure
+  }
+
+  test("transform() a Term.ApplyInfix, when inner transformer returns a result after a right-shift - should return it") {
+    val matcher = q"""contain("a") and have size 4"""
+    val shiftedMatcher = q"""contain("a") and (have size 4)"""
+    val expectedHamcrestMatcher = q"is(3)"
+
+    when(innerTransformer.transform(any[Term.ApplyInfix])).thenAnswer((infix: Term.ApplyInfix) => infix match {
+      case anInfix if anInfix.structure == shiftedMatcher.structure => Some(expectedHamcrestMatcher)
+      case _ => None
+    })
+
+    when(termApplyInfixManipulator.rightShiftInnerIfPossible(any[Term.ApplyInfix])).thenAnswer((infix: Term.ApplyInfix) => infix match {
+      case anInfix if anInfix.structure == matcher.structure => Some(shiftedMatcher)
+      case _ => None
+    })
+
+    outerTransformer.transform(matcher).value.structure shouldBe expectedHamcrestMatcher.structure
+  }
+
+  test("transform() a Term.ApplyInfix, when inner transformer does not return a result and right-shift not possible - should return None") {
+    val matcher = q"bla bla(3)"
+
+    when(innerTransformer.transform(eqTree(matcher))).thenReturn(None)
+
+    when(termApplyInfixManipulator.rightShiftInnerIfPossible(eqTree(matcher))).thenReturn(None)
+
+    outerTransformer.transform(matcher) shouldBe None
+  }
+
+  test("transform() a Term.Apply, when inner transformer returns a result - should return it") {
+    val matcher = q"be(3)"
+    val expectedHamcrestMatcher = q"is(3)"
+
+    when(innerTransformer.transform(eqTree(matcher))).thenReturn(Some(expectedHamcrestMatcher))
+
+    outerTransformer.transform(matcher).value.structure shouldBe expectedHamcrestMatcher.structure
+  }
+
+  test("transform() a Term.Apply, when inner transformer returns None - should return None") {
+    val matcher = q"bla(3)"
+
+    when(innerTransformer.transform(eqTree(matcher))).thenReturn(None)
+
+    outerTransformer.transform(matcher) shouldBe None
+  }
+
+
+}


### PR DESCRIPTION
This is a preparation for supporting a transformation of the `and` matcher , which can be used in complex infix expressions